### PR TITLE
0.0.4: Update to *ring* 0.9.4.

### DIFF
--- a/ring/Cargo.toml
+++ b/ring/Cargo.toml
@@ -4,13 +4,13 @@ license = "Unlicense"
 name = "noise-ring"
 readme = "README.md"
 repository = "https://github.com/sopium/noise-rust"
-version = "0.0.3"
+version = "0.0.4"
 description = "Ring wrappers for nosie-protocol."
 documentation = "https://docs.rs/noise-ring/0.0.3"
 
 [dependencies]
 byteorder = "1.0.0"
-ring = "0.7.1"
+ring = "0.9.4"
 
 [dependencies.noise-protocol]
 path = "../noise"


### PR DESCRIPTION
Before *ring* 0.9.3, it was possible to link multiple versions of *ring* into a program, e.g. if one version depended on *ring* 0.6 and another depended on *ring* 0.9. Unfortunately, this doesn't work, because the linker doesn't know to how to link *ring*'s C/asm code correctly in that kind of situation. *ring* 0.9.3 added a flag to its Cargo.toml to tell the Rust toolchain to stop allowing multiple versions of *ring* to be linked into the same program, to prevent any problems this may cause.

*ring* 0.9.4 was released with an update to make some crates easier to update to 0.9.x.