### PR TITLE
noise-rust-crypto: make x25519-dalek dep configurable

### DIFF
--- a/noise-rust-crypto/Cargo.toml
+++ b/noise-rust-crypto/Cargo.toml
@@ -10,14 +10,18 @@ description = "Wrappers of dalek and RustCrypto crates for noise-protocol"
 
 [features]
 default = ["use-x25519", "use-chacha20poly1305", "use-aes-256-gcm", "use-blake2", "use-sha2"]
-use-x25519 = ["x25519-dalek", "getrandom"]
+x25519 = ["x25519-dalek", "getrandom"]
+x25519-std = ["x25519", "x25519-dalek/std"]
+x25519-u64_backend = ["x25519", "x25519-dalek/u64_backend"]
+x25519-u32_backend = ["x25519", "x25519-dalek/u32_backend"]
+use-x25519 = ["x25519", "x25519-dalek/default"]
 use-chacha20poly1305 = ["chacha20poly1305", "aead"]
 use-aes-256-gcm = ["aes-gcm", "aead"]
 use-blake2 = ["blake2", "digest"]
 use-sha2 = ["sha2", "digest"]
 
 [dependencies]
-x25519-dalek = { version = "0.6.0", optional = true }
+x25519-dalek = { version = "0.6.0", optional = true, default-features = false }
 aes-gcm = { version = "0.5.0", optional = true }
 chacha20poly1305 = { version = "0.4.1", optional = true }
 blake2 = { version = "0.8.1", optional = true }

--- a/noise-rust-crypto/src/lib.rs
+++ b/noise-rust-crypto/src/lib.rs
@@ -19,13 +19,13 @@ use aead::{Aead, NewAead};
 #[cfg(any(feature = "use-blake2", feature = "use-sha2",))]
 use digest::Digest;
 use noise_protocol::*;
-#[cfg(feature = "use-x25519")]
+#[cfg(feature = "x25519")]
 use x25519_dalek::{PublicKey, StaticSecret};
 
-#[cfg(feature = "use-x25519")]
+#[cfg(feature = "x25519")]
 pub enum X25519 {}
 
-#[cfg(feature = "use-x25519")]
+#[cfg(feature = "x25519")]
 impl DH for X25519 {
     type Key = [u8; 32];
     type Pubkey = [u8; 32];


### PR DESCRIPTION
More fine grained feature configuration allows a user to choose a
different backend and disable std.

This change is backwards compatible.