### PR TITLE
noise-rust-crypto: make it work on no_std

### DIFF
--- a/noise-rust-crypto/Cargo.toml
+++ b/noise-rust-crypto/Cargo.toml
@@ -25,7 +25,7 @@ x25519-dalek = { version = "0.6.0", optional = true, default-features = false }
 aes-gcm = { version = "0.5.0", optional = true }
 chacha20poly1305 = { version = "0.4.1", optional = true }
 blake2 = { version = "0.8.1", optional = true }
-sha2 = { version = "0.8.0", optional = true }
+sha2 = { version = "0.8.0", optional = true, default-features = false }
 aead = { version = "0.2.0", optional = true }
 getrandom = { version = "0.1.12", optional = true }
 digest = { version = "0.8.1", optional = true }
@@ -33,6 +33,7 @@ digest = { version = "0.8.1", optional = true }
 [dependencies.noise-protocol]
 path = "../noise-protocol"
 version = "0.1.2-dev"
+default-features = false
 
 [dev-dependencies]
 hex = "0.4"


### PR DESCRIPTION
The default features of the sha2 and noise_protocol deps pull in
std. They are not needed in noise-rust-crypto to implement the traits.