### PR TITLE
noise-protocol: add feature use_alloc for when alloc available

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Test vectors from [cacophony](https://github.com/centromere/cacophony) and [snow
 ## Philosophy
 
 * Simple: straightforward implementation, small amount of code, almost no
-  dependencies, supports `no_std`.
+  dependencies, supports `no_std`. Feature `use_alloc` can optionallly be used
+  as an alternative to std.
 * Fast: static dispatch, no heap allocation necessary.
 * Unopinionated: flexible, primitive API, does not dictate how it should be
   used.

--- a/noise-protocol/Cargo.toml
+++ b/noise-protocol/Cargo.toml
@@ -16,3 +16,4 @@ arrayvec = { version = "0.5", default-features = false }
 [features]
 default = ["use_std"]
 use_std = []
+use_alloc = []

--- a/noise-protocol/src/cipherstate.rs
+++ b/noise-protocol/src/cipherstate.rs
@@ -1,5 +1,8 @@
 use crate::traits::{Cipher, U8Array};
 
+#[cfg(feature = "use_alloc")]
+use alloc::vec::Vec;
+
 /// A `CipherState` can encrypt and decrypt data.
 ///
 /// Mostly like `CipherState` in the spec, but must be created with a key.
@@ -71,7 +74,7 @@ where
     }
 
     /// Encryption, returns ciphertext as `Vec<u8>`.
-    #[cfg(feature = "use_std")]
+    #[cfg(any(feature = "use_std", feature = "use_alloc"))]
     pub fn encrypt_vec(&mut self, plaintext: &[u8]) -> Vec<u8> {
         let mut out = vec![0u8; plaintext.len() + 16];
         self.encrypt(plaintext, &mut out);
@@ -84,7 +87,7 @@ where
     }
 
     /// Decryption, returns plaintext as `Vec<u8>`.
-    #[cfg(feature = "use_std")]
+    #[cfg(any(feature = "use_std", feature = "use_alloc"))]
     pub fn decrypt_vec(&mut self, ciphertext: &[u8]) -> Result<Vec<u8>, ()> {
         if ciphertext.len() < 16 {
             return Err(());

--- a/noise-protocol/src/handshakestate.rs
+++ b/noise-protocol/src/handshakestate.rs
@@ -5,6 +5,9 @@ use crate::traits::{Cipher, Hash, U8Array, DH};
 use arrayvec::{ArrayString, ArrayVec};
 use core::fmt::{Display, Error as FmtError, Formatter, Write};
 
+#[cfg(feature = "use_alloc")]
+use alloc::vec::Vec;
+
 /// Noise handshake state.
 pub struct HandshakeState<D: DH, C: Cipher, H: Hash> {
     symmetric: SymmetricState<C, H>,
@@ -187,7 +190,7 @@ where
     }
 
     /// Like [`write_message`](HandshakeState::write_message), but returns a [`Vec`].
-    #[cfg(feature = "use_std")]
+    #[cfg(any(feature = "use_std", feature = "use_alloc"))]
     pub fn write_message_vec(&mut self, payload: &[u8]) -> Result<Vec<u8>, Error> {
         let mut out = vec![0u8; payload.len() + self.get_next_message_overhead()];
         self.write_message(payload, &mut out)?;
@@ -365,7 +368,7 @@ where
     /// In addition to possible errors from
     /// [`read_message`](HandshakeState::read_message),
     /// [TooShort](ErrorKind::TooShort) may be returned.
-    #[cfg(feature = "use_std")]
+    #[cfg(any(feature = "use_std", feature = "use_alloc"))]
     pub fn read_message_vec(&mut self, data: &[u8]) -> Result<Vec<u8>, Error> {
         let overhead = self.get_next_message_overhead();
         if data.len() < overhead {

--- a/noise-protocol/src/lib.rs
+++ b/noise-protocol/src/lib.rs
@@ -28,6 +28,10 @@ mod handshakestate;
 mod symmetricstate;
 mod traits;
 
+#[cfg(feature = "use_alloc")]
+#[macro_use]
+extern crate alloc;
+
 pub use crate::cipherstate::CipherState;
 pub use crate::traits::{Cipher, Hash, U8Array, DH};
 


### PR DESCRIPTION
In no_std, if an allocator exists, the Vec-based functions could still
be used. This feature allows getting back the std features via alloc.

This change is backwards compatible.