### PR TITLE
get & set message index of handshake state manually

### DIFF
--- a/noise-protocol/src/handshakestate.rs
+++ b/noise-protocol/src/handshakestate.rs
@@ -433,6 +433,16 @@ where
         &self.pattern
     }
 
+    /// Get the message index of this [`HandshakeState`].
+    pub fn get_index(&self) -> usize {
+        self.message_index
+    }
+
+    /// Set the message index of this [`HandshakeState`] manually.
+    pub fn set_index(&mut self, index: usize) {
+        self.message_index = index;
+    }
+
     fn perform_dh(&self, t: Token) -> Result<D::Output, ()> {
         let dh = |a: Option<&D::Key>, b: Option<&D::Pubkey>| D::dh(a.unwrap(), b.unwrap());
 


### PR DESCRIPTION
For delay tolerant messaging, one needs to be able to safe and reconstruct the state of the `HandshakeState` structure manually.
Therefore the exposure of the message index is needed.

The following getters and setters were added to the `HandshakeState` implementation:

* `pub fn get_index(&self) -> usize`
* `pub fn set_index(&mut self, index: usize)`