### PR TITLE
bring back nose-ring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["noise-protocol", "noise-rust-crypto", "vectors"]
+members = ["noise-protocol", "noise-rust-crypto", "noise-ring", "vectors"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ supports:
 
 |             | X25519 | AES-256-GCM | Chacha20-Poly1305 | SHA-256 | SHA-512 | BLAKE2s | BLAKE2b |
 |-------------|:------:|:-----------:|:-----------------:|:-------:|:-------:|:-------:|:-------:|
+| rust-ring   |        | ✔           | ✔                 | ✔       | ✔       |         |         |
 | rust-crypto | ✔      | ✔           | ✔                 | ✔       | ✔       | ✔       | ✔       |
 
 You can also plug in other primitive implementations by implementing the `DH`,

--- a/noise-ring/Cargo.toml
+++ b/noise-ring/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+edition = "2021"
+authors = ["Guanhao Yin <sopium@mysterious.site>"]
+license = "Unlicense"
+name = "noise-ring"
+readme = "README.md"
+repository = "https://github.com/sopium/noise-rust"
+version = "0.2.0"
+description = "Ring wrappers for nosie-protocol."
+
+[dependencies]
+ring = "0.16"
+zeroize = "1"
+
+[dependencies.noise-protocol]
+path = "../noise-protocol"
+version = "0.1"

--- a/noise-ring/README.md
+++ b/noise-ring/README.md
@@ -1,0 +1,1 @@
+This crate provides wrappers of _ring_ for `nosie-rust`.

--- a/noise-ring/src/lib.rs
+++ b/noise-ring/src/lib.rs
@@ -1,0 +1,277 @@
+#![no_std]
+
+pub mod sensitive;
+use sensitive::Sensitive;
+
+use noise_protocol::{Cipher, Hash};
+use ring::{
+    aead::{self, LessSafeKey, UnboundKey},
+    digest,
+};
+
+pub struct Sha256 {
+    context: digest::Context,
+}
+
+pub struct Sha512 {
+    context: digest::Context,
+}
+
+impl Default for Sha256 {
+    fn default() -> Sha256 {
+        Sha256 {
+            context: digest::Context::new(&digest::SHA256),
+        }
+    }
+}
+
+impl Hash for Sha256 {
+    type Block = [u8; 64];
+    type Output = [u8; 32];
+
+    fn name() -> &'static str {
+        "SHA256"
+    }
+
+    fn input(&mut self, data: &[u8]) {
+        self.context.update(data);
+    }
+
+    fn result(&mut self) -> Self::Output {
+        let mut out = [0u8; 32];
+        // XXX have to clone becuase finish() moves Context.
+        out.copy_from_slice(self.context.clone().finish().as_ref());
+        out
+    }
+}
+
+impl Default for Sha512 {
+    fn default() -> Sha512 {
+        Sha512 {
+            context: digest::Context::new(&digest::SHA512),
+        }
+    }
+}
+
+impl Hash for Sha512 {
+    type Block = [u8; 128];
+    type Output = [u8; 64];
+
+    fn name() -> &'static str {
+        "SHA512"
+    }
+
+    fn input(&mut self, data: &[u8]) {
+        self.context.update(data);
+    }
+
+    fn result(&mut self) -> Self::Output {
+        let mut out = [0u8; 64];
+        out.copy_from_slice(self.context.clone().finish().as_ref());
+        out
+    }
+}
+
+const TAGLEN: usize = 16;
+
+pub enum ChaCha20Poly1305 {}
+
+impl Cipher for ChaCha20Poly1305 {
+    fn name() -> &'static str {
+        "ChaChaPoly"
+    }
+
+    type Key = Sensitive<[u8; 32]>;
+
+    fn encrypt(k: &Self::Key, nonce: u64, ad: &[u8], plaintext: &[u8], out: &mut [u8]) {
+        assert!(plaintext.len().checked_add(TAGLEN) == Some(out.len()));
+
+        let mut nonce_bytes = [0u8; 12];
+        nonce_bytes[4..].copy_from_slice(&nonce.to_le_bytes());
+        let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
+
+        let key =
+            LessSafeKey::new(UnboundKey::new(&aead::CHACHA20_POLY1305, k.as_slice()).unwrap());
+
+        let (in_out, tag_out) = out.split_at_mut(plaintext.len());
+        in_out.copy_from_slice(plaintext);
+
+        let tag = key
+            .seal_in_place_separate_tag(nonce, aead::Aad::from(ad), in_out)
+            .unwrap();
+        tag_out.copy_from_slice(tag.as_ref());
+    }
+
+    fn encrypt_in_place(
+        k: &Self::Key,
+        nonce: u64,
+        ad: &[u8],
+        in_out: &mut [u8],
+        plaintext_len: usize,
+    ) -> usize {
+        assert!(plaintext_len
+            .checked_add(TAGLEN)
+            .map_or(false, |l| l <= in_out.len()));
+
+        let mut nonce_bytes = [0u8; 12];
+        nonce_bytes[4..].copy_from_slice(&nonce.to_le_bytes());
+        let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
+
+        let key =
+            LessSafeKey::new(UnboundKey::new(&aead::CHACHA20_POLY1305, k.as_slice()).unwrap());
+
+        let (in_out, tag_out) = in_out[..plaintext_len + TAGLEN].split_at_mut(plaintext_len);
+        let tag = key
+            .seal_in_place_separate_tag(nonce, aead::Aad::from(ad), in_out)
+            .unwrap();
+        tag_out.copy_from_slice(tag.as_ref());
+
+        plaintext_len + TAGLEN
+    }
+
+    fn decrypt(
+        k: &Self::Key,
+        nonce: u64,
+        ad: &[u8],
+        ciphertext: &[u8],
+        out: &mut [u8],
+    ) -> Result<(), ()> {
+        assert!(ciphertext.len().checked_sub(TAGLEN) == Some(out.len()));
+
+        let mut nonce_bytes = [0u8; 12];
+        nonce_bytes[4..].copy_from_slice(&nonce.to_le_bytes());
+        let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
+
+        let key =
+            LessSafeKey::new(UnboundKey::new(&aead::CHACHA20_POLY1305, k.as_slice()).unwrap());
+        let mut in_out = ciphertext.to_vec();
+
+        let out0 = key
+            .open_in_place(nonce, aead::Aad::from(ad), &mut in_out)
+            .map_err(|_| ())?;
+
+        out[..out0.len()].copy_from_slice(out0);
+        Ok(())
+    }
+
+    fn decrypt_in_place(
+        k: &Self::Key,
+        nonce: u64,
+        ad: &[u8],
+        in_out: &mut [u8],
+        ciphertext_len: usize,
+    ) -> Result<usize, ()> {
+        assert!(ciphertext_len <= in_out.len());
+        assert!(ciphertext_len >= TAGLEN);
+
+        let mut nonce_bytes = [0u8; 12];
+        nonce_bytes[4..].copy_from_slice(&nonce.to_le_bytes());
+        let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
+
+        let key =
+            LessSafeKey::new(UnboundKey::new(&aead::CHACHA20_POLY1305, k.as_slice()).unwrap());
+        key.open_in_place(nonce, aead::Aad::from(ad), &mut in_out[..ciphertext_len])
+            .map_err(|_| ())?;
+
+        Ok(ciphertext_len - TAGLEN)
+    }
+}
+
+pub enum Aes256Gcm {}
+
+impl Cipher for Aes256Gcm {
+    fn name() -> &'static str {
+        "AESGCM"
+    }
+
+    type Key = Sensitive<[u8; 32]>;
+
+    fn encrypt(k: &Self::Key, nonce: u64, ad: &[u8], plaintext: &[u8], out: &mut [u8]) {
+        assert!(plaintext.len().checked_add(TAGLEN) == Some(out.len()));
+
+        let mut nonce_bytes = [0u8; 12];
+        nonce_bytes[4..].copy_from_slice(&nonce.to_be_bytes());
+        let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
+
+        let key = LessSafeKey::new(UnboundKey::new(&aead::AES_256_GCM, k.as_slice()).unwrap());
+
+        let (in_out, tag_out) = out.split_at_mut(plaintext.len());
+        in_out.copy_from_slice(plaintext);
+
+        let tag = key
+            .seal_in_place_separate_tag(nonce, aead::Aad::from(ad), in_out)
+            .unwrap();
+        tag_out.copy_from_slice(tag.as_ref());
+    }
+
+    fn encrypt_in_place(
+        k: &Self::Key,
+        nonce: u64,
+        ad: &[u8],
+        in_out: &mut [u8],
+        plaintext_len: usize,
+    ) -> usize {
+        assert!(plaintext_len
+            .checked_add(TAGLEN)
+            .map_or(false, |l| l <= in_out.len()));
+
+        let mut nonce_bytes = [0u8; 12];
+        nonce_bytes[4..].copy_from_slice(&nonce.to_be_bytes());
+        let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
+
+        let key = LessSafeKey::new(UnboundKey::new(&aead::AES_256_GCM, k.as_slice()).unwrap());
+
+        let (in_out, tag_out) = in_out[..plaintext_len + TAGLEN].split_at_mut(plaintext_len);
+        let tag = key
+            .seal_in_place_separate_tag(nonce, aead::Aad::from(ad), in_out)
+            .unwrap();
+        tag_out.copy_from_slice(tag.as_ref());
+
+        plaintext_len + TAGLEN
+    }
+
+    fn decrypt(
+        k: &Self::Key,
+        nonce: u64,
+        ad: &[u8],
+        ciphertext: &[u8],
+        out: &mut [u8],
+    ) -> Result<(), ()> {
+        assert!(ciphertext.len().checked_sub(TAGLEN) == Some(out.len()));
+
+        let mut nonce_bytes = [0u8; 12];
+        nonce_bytes[4..].copy_from_slice(&nonce.to_be_bytes());
+        let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
+
+        let key = LessSafeKey::new(UnboundKey::new(&aead::AES_256_GCM, k.as_slice()).unwrap());
+        let mut in_out = ciphertext.to_vec();
+
+        let out0 = key
+            .open_in_place(nonce, aead::Aad::from(ad), &mut in_out)
+            .map_err(|_| ())?;
+
+        out[..out0.len()].copy_from_slice(out0);
+        Ok(())
+    }
+
+    fn decrypt_in_place(
+        k: &Self::Key,
+        nonce: u64,
+        ad: &[u8],
+        in_out: &mut [u8],
+        ciphertext_len: usize,
+    ) -> Result<usize, ()> {
+        assert!(ciphertext_len <= in_out.len());
+        assert!(ciphertext_len >= TAGLEN);
+
+        let mut nonce_bytes = [0u8; 12];
+        nonce_bytes[4..].copy_from_slice(&nonce.to_be_bytes());
+        let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
+
+        let key = LessSafeKey::new(UnboundKey::new(&aead::AES_256_GCM, k.as_slice()).unwrap());
+        key.open_in_place(nonce, aead::Aad::from(ad), &mut in_out[..ciphertext_len])
+            .map_err(|_| ())?;
+
+        Ok(ciphertext_len - TAGLEN)
+    }
+}

--- a/noise-ring/src/sensitive.rs
+++ b/noise-ring/src/sensitive.rs
@@ -1,0 +1,53 @@
+use noise_protocol::U8Array;
+use zeroize::{Zeroize, Zeroizing};
+
+/// Struct holding a value that is safely zeroed on drop.
+pub struct Sensitive<A: U8Array + Zeroize>(Zeroizing<A>);
+
+impl<A: U8Array + Zeroize> Sensitive<A> {
+    pub fn from(a: Zeroizing<A>) -> Self {
+        Sensitive(a)
+    }
+}
+
+impl<A: U8Array + Zeroize> core::ops::Deref for Sensitive<A> {
+    type Target = A;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<A: U8Array + Zeroize> core::ops::DerefMut for Sensitive<A> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<A> U8Array for Sensitive<A>
+where
+    A: Zeroize + U8Array,
+{
+    fn new() -> Self {
+        Sensitive::from(Zeroizing::new(A::new()))
+    }
+
+    fn new_with(v: u8) -> Self {
+        Sensitive::from(Zeroizing::new(A::new_with(v)))
+    }
+
+    fn from_slice(s: &[u8]) -> Self {
+        Sensitive::from(Zeroizing::new(A::from_slice(s)))
+    }
+
+    fn len() -> usize {
+        A::len()
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0.as_mut()
+    }
+}

--- a/vectors/Cargo.toml
+++ b/vectors/Cargo.toml
@@ -9,6 +9,7 @@ build = "build.rs"
 hex = "0.4.0"
 lazy_static = "1.1"
 noise-protocol = { path = "../noise-protocol" }
+noise-ring = { path = "../noise-ring" }
 noise-rust-crypto = { path = "../noise-rust-crypto" }
 rayon = "1.0"
 regex = "1.0"

--- a/vectors/build.rs
+++ b/vectors/build.rs
@@ -12,12 +12,18 @@ fn gen<O: Write>(mut out: O) -> ::std::io::Result<()> {
     dhs.insert("25519", vec!["crypto::X25519"]);
 
     let mut ciphers = HashMap::new();
-    ciphers.insert("ChaChaPoly", vec!["crypto::ChaCha20Poly1305"]);
-    ciphers.insert("AESGCM", vec!["crypto::Aes256Gcm"]);
+    ciphers.insert(
+        "ChaChaPoly",
+        vec!["crypto::ChaCha20Poly1305", "ring_crypto::ChaCha20Poly1305"],
+    );
+    ciphers.insert(
+        "AESGCM",
+        vec!["crypto::Aes256Gcm", "ring_crypto::Aes256Gcm"],
+    );
 
     let mut hashes: HashMap<&str, Vec<&str>> = HashMap::new();
-    hashes.insert("SHA256", vec!["crypto::Sha256"]);
-    hashes.insert("SHA512", vec!["crypto::Sha512"]);
+    hashes.insert("SHA256", vec!["crypto::Sha256", "ring_crypto::Sha256"]);
+    hashes.insert("SHA512", vec!["crypto::Sha512", "ring_crypto::Sha512"]);
     hashes.insert("BLAKE2s", vec!["crypto::Blake2s"]);
     hashes.insert("BLAKE2b", vec!["crypto::Blake2b"]);
 

--- a/vectors/tests/vectors.rs
+++ b/vectors/tests/vectors.rs
@@ -8,6 +8,7 @@ use lazy_static::lazy_static;
 use noise::patterns::*;
 use noise::*;
 use noise_protocol as noise;
+use noise_ring as ring_crypto;
 use noise_rust_crypto as crypto;
 use rayon::prelude::*;
 use regex::Regex;


### PR DESCRIPTION
Hi, 👋 

I recently noticed that the noise-ring library was deprecated because it didn't support `ChaCha20Poly1305` and `Aes256Gcm` and was less useful. However, after going through the snow code, I found out that it was possible to support these encryption methods, so I created this PR.

Currently, `Sensitive` depends on `noise_rust_crypto`. Perhaps it could be moved into `noise-protocol`?

On my computer (M1 pro 10C), `ring`'s throughput is 2.5 times that of `rust-crypto`. Additionally, symmetric encryption is a hot path in the noise protocol, so I believe including `noise-ring` is necessary.

👉👉👉 Take a look and let me know what you think! 🚀
