### PR TITLE
add encrypt_in_place and decrypt_in_place for Cipher

### DIFF
--- a/noise-protocol/src/traits.rs
+++ b/noise-protocol/src/traits.rs
@@ -107,6 +107,20 @@ pub trait Cipher {
     /// If `out.len() != plaintext.len() + Self::tag_len()`
     fn encrypt(k: &Self::Key, nonce: u64, ad: &[u8], plaintext: &[u8], out: &mut [u8]);
 
+    /// AEAD encryption, but encrypt on one buffer.
+    /// return the length of ciphertext.
+    ///
+    /// # Panics
+    ///
+    /// If `in_out.len() < plaintext_len + Self::tag_len()`
+    fn encrypt_in_place(
+        k: &Self::Key,
+        nonce: u64,
+        ad: &[u8],
+        in_out: &mut [u8],
+        plaintext_len: usize,
+    ) -> usize;
+
     /// AEAD decryption.
     ///
     /// # Panics
@@ -119,6 +133,20 @@ pub trait Cipher {
         ciphertext: &[u8],
         out: &mut [u8],
     ) -> Result<(), ()>;
+
+    /// AEAD decryption, but decrypt on one buffer.
+    /// return the length of plaintext.
+    ///
+    /// # Panics
+    ///
+    /// If `in_out.len() < ciphertext_len` or `ciphertext_len < Self::tag_len()`
+    fn decrypt_in_place(
+        k: &Self::Key,
+        nonce: u64,
+        ad: &[u8],
+        in_out: &mut [u8],
+        ciphertext_len: usize,
+    ) -> Result<usize, ()>;
 
     /// Rekey. Returns a new cipher key as a pseudorandom function of `k`.
     fn rekey(k: &Self::Key) -> Self::Key {


### PR DESCRIPTION
After the handshake, use `CipherState` for encrypted transmission. If I use the current API, I need to apply for two buffers for encryption or decryption (a total of four buffers). The new API only requires one for encryption and another for decryption and saves one memory copy for each call.

If you're not satisfied with the name of the API, we can discuss it further. 😊

If this PR is finally merged and before #45, I will use the new API in #45. Otherwise, I will update the API needed for `noise-ring`.