### PR TITLE
upgrade deps

### DIFF
--- a/noise-protocol/Cargo.toml
+++ b/noise-protocol/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 authors = ["trevp", "Guanhao Yin <sopium@mysterious.site>"]
 license = "Unlicense"
 name = "noise-protocol"

--- a/noise-rust-crypto/Cargo.toml
+++ b/noise-rust-crypto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 authors = ["Guanhao Yin <sopium@mysterious.site>"]
 license = "Unlicense"
 name = "noise-rust-crypto"
@@ -10,10 +10,7 @@ description = "Wrappers of dalek and RustCrypto crates for noise-protocol"
 
 [features]
 default = ["use-x25519", "use-chacha20poly1305", "use-aes-256-gcm", "use-blake2", "use-sha2"]
-x25519 = ["x25519-dalek", "getrandom"]
-x25519-std = ["x25519", "x25519-dalek/std"]
-x25519-u64_backend = ["x25519", "x25519-dalek/u64_backend"]
-x25519-u32_backend = ["x25519", "x25519-dalek/u32_backend"]
+x25519 = ["x25519-dalek", "x25519-dalek/static_secrets", "x25519-dalek/getrandom"]
 use-x25519 = ["x25519", "x25519-dalek/default"]
 use-chacha20poly1305 = ["chacha20poly1305"]
 use-aes-256-gcm = ["aes-gcm"]
@@ -21,13 +18,12 @@ use-blake2 = ["blake2"]
 use-sha2 = ["sha2"]
 
 [dependencies]
-x25519-dalek = { version = "1.2.0", optional = true, default-features = false }
-aes-gcm = { version = "0.9.4", optional = true }
-chacha20poly1305 = { version = "0.9.0", optional = true }
-blake2 = { version = "0.10.4", optional = true }
-sha2 = { version = "0.10.2", optional = true, default-features = false }
-getrandom = { version = "0.2.5", optional = true }
-zeroize = "1.3.0"
+x25519-dalek = { version = "2.0.0-rc.2", optional = true, default-features = false }
+aes-gcm = { version = "0.10.1", optional = true }
+chacha20poly1305 = { version = "0.10.1", optional = true }
+blake2 = { version = "0.10.6", optional = true }
+sha2 = { version = "0.10.6", optional = true, default-features = false }
+zeroize = "1"
 
 [dependencies.noise-protocol]
 path = "../noise-protocol"

--- a/vectors/Cargo.toml
+++ b/vectors/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-edition = "2018"
+edition = "2021"
 name = "noise-vectors"
 version = "0.0.0"
 authors = ["Guanhao Yin <sopium@mysterious.site>"]
 build = "build.rs"
 
 [dev-dependencies]
-hex = "0.4.0"
-lazy_static = "1.1"
+hex = "0.4.3"
+lazy_static = "1.4"
 noise-protocol = { path = "../noise-protocol" }
 noise-rust-crypto = { path = "../noise-rust-crypto" }
-rayon = "1.0"
-regex = "1.0"
+rayon = "1.7"
+regex = "1.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Hi,

👋 I'm submitting this pull request to address issues #48 and #49, it would break `cargo check`.

This PR includes a destructive update because `x25519-dalek` has specific version requirements for `zeroize`. However, this issue has been resolved in the latest 2.0-rc2 release of `x25519-dalek`. It's been over a year since version 1.2 of `x25519-dalek`, but rc2 was released a few days ago and should be stable enough.

`x25519-dalek` use `rand_core` 0.6, so I remove old getrandom

I've also made changes to the features of `x25519-dalek` by removing those that are no longer available.

In addition, I've fixed all versions in the x.y.z format to x.y. All edition field use 2021

Finally, I've passed all current tests using `test.sh`.