### PR TITLE
make getrandom optional

### DIFF
--- a/noise-protocol/Cargo.toml
+++ b/noise-protocol/Cargo.toml
@@ -17,3 +17,4 @@ arrayvec = { version = "0.7.2", default-features = false }
 default = ["use_std"]
 use_std = []
 use_alloc = []
+use_getrandom = []

--- a/noise-protocol/src/traits.rs
+++ b/noise-protocol/src/traits.rs
@@ -71,6 +71,7 @@ pub trait DH {
     /// Name of this DH function, e.g., “25519”.
     fn name() -> &'static str;
 
+    #[cfg(feature = "use_getrandom")]
     /// Randomly generate a new private key.
     fn genkey() -> Self::Key;
 

--- a/noise-rust-crypto/Cargo.toml
+++ b/noise-rust-crypto/Cargo.toml
@@ -9,21 +9,22 @@ version = "0.6.0-rc.1"
 description = "Wrappers of dalek and RustCrypto crates for noise-protocol"
 
 [features]
-default = ["use-x25519", "use-chacha20poly1305", "use-aes-256-gcm", "use-blake2", "use-sha2"]
-x25519 = ["x25519-dalek", "x25519-dalek/static_secrets", "x25519-dalek/getrandom"]
-use-x25519 = ["x25519", "x25519-dalek/default"]
+default = ["use-x25519", "use-chacha20poly1305", "use-aes-256-gcm", "use-blake2", "use-sha2", "use_getrandom"]
+x25519 = ["x25519-dalek", "x25519-dalek/static_secrets"]
+use-x25519 = ["x25519", "x25519-dalek/precomputed-tables", "x25519-dalek/zeroize"]
 use-chacha20poly1305 = ["chacha20poly1305"]
 use-aes-256-gcm = ["aes-gcm"]
 use-blake2 = ["blake2"]
 use-sha2 = ["sha2"]
+use_getrandom = ["noise-protocol/use_getrandom", "x25519-dalek?/getrandom"]
 
 [dependencies]
 x25519-dalek = { version = "2.0.0-rc.2", optional = true, default-features = false }
-aes-gcm = { version = "0.10.1", optional = true }
+aes-gcm = { version = "0.10.1", features = ["aes"], default-features = false, optional = true }
 chacha20poly1305 = { version = "0.10.1", optional = true }
 blake2 = { version = "0.10.6", optional = true }
 sha2 = { version = "0.10.6", optional = true, default-features = false }
-zeroize = "1"
+zeroize = { version = "1", default-features = false }
 
 [dependencies.noise-protocol]
 path = "../noise-protocol"

--- a/noise-rust-crypto/src/lib.rs
+++ b/noise-rust-crypto/src/lib.rs
@@ -32,6 +32,7 @@ impl DH for X25519 {
         "25519"
     }
 
+    #[cfg(feature = "use_getrandom")]
     fn genkey() -> Self::Key {
         Self::Key::from_slice(StaticSecret::random().as_bytes())
     }


### PR DESCRIPTION
I don't have getrandom, so I'd like to provide my own ephemeral key for the HandshakeState

I hide useage of getrandom (i.e. `DH::genkey()`) behind the "use_getrandom" feature. 

Patters that require an ephemeral key then return Err() when E was not  provided in `HandshakeState::new`