### PR TITLE
upgrade deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
+resolver = "2"
 members = ["noise-protocol", "noise-rust-crypto", "noise-ring", "vectors"]

--- a/noise-protocol/Cargo.toml
+++ b/noise-protocol/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["noise"]
 categories = ["cryptography"]
 
 [dependencies]
-arrayvec = { version = "0.7.2", default-features = false }
+arrayvec = { version = "0.7.4", default-features = false }
 
 [features]
 default = ["use_std"]

--- a/noise-ring/Cargo.toml
+++ b/noise-ring/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.2.0-rc.1"
 description = "Ring wrappers for nosie-protocol."
 
 [dependencies]
-ring = "0.16"
+ring = "0.17"
 zeroize = "1"
 
 [dependencies.noise-protocol]

--- a/noise-rust-crypto/Cargo.toml
+++ b/noise-rust-crypto/Cargo.toml
@@ -18,11 +18,11 @@ use-blake2 = ["blake2"]
 use-sha2 = ["sha2"]
 
 [dependencies]
-x25519-dalek = { version = "2.0.0-rc.2", optional = true, default-features = false }
-aes-gcm = { version = "0.10.1", optional = true }
+x25519-dalek = { version = "2.0.0", optional = true, default-features = false }
+aes-gcm = { version = "0.10.3", optional = true }
 chacha20poly1305 = { version = "0.10.1", optional = true }
 blake2 = { version = "0.10.6", optional = true }
-sha2 = { version = "0.10.6", optional = true, default-features = false }
+sha2 = { version = "0.10.8", optional = true, default-features = false }
 zeroize = "1"
 
 [dependencies.noise-protocol]


### PR DESCRIPTION
The main upgrades are the release of a stable version of `x25519-dalek` and the recent update of ring to 0.17.

In addition, warning appears in my rust version (v1.72.1), so I added `resolver = "2"` to eliminate warning.

BTW, noise-rust is currently rc, should be time to release the official version?

