### PR TITLE
adjust features to not require alloc

### DIFF
--- a/noise-rust-crypto/Cargo.toml
+++ b/noise-rust-crypto/Cargo.toml
@@ -10,8 +10,8 @@ description = "Wrappers of dalek and RustCrypto crates for noise-protocol"
 
 [features]
 default = ["use-x25519", "use-chacha20poly1305", "use-aes-256-gcm", "use-blake2", "use-sha2"]
-x25519 = ["x25519-dalek", "x25519-dalek/static_secrets", "x25519-dalek/getrandom"]
-use-x25519 = ["x25519", "x25519-dalek/default"]
+x25519 = ["x25519-dalek", "x25519-dalek/static_secrets"]
+use-x25519 = ["x25519", "x25519-dalek/precomputed-tables", "x25519-dalek/zeroize", "x25519-dalek/getrandom"]
 use-chacha20poly1305 = ["chacha20poly1305"]
 use-aes-256-gcm = ["aes-gcm"]
 use-blake2 = ["blake2"]
@@ -19,11 +19,11 @@ use-sha2 = ["sha2"]
 
 [dependencies]
 x25519-dalek = { version = "2.0.0-rc.2", optional = true, default-features = false }
-aes-gcm = { version = "0.10.1", optional = true }
+aes-gcm = { version = "0.10.1", features = ["aes"], default-features = false, optional = true }
 chacha20poly1305 = { version = "0.10.1", optional = true }
 blake2 = { version = "0.10.6", optional = true }
 sha2 = { version = "0.10.6", optional = true, default-features = false }
-zeroize = "1"
+zeroize = { version = "1", default-features = false }
 
 [dependencies.noise-protocol]
 path = "../noise-protocol"


### PR DESCRIPTION
Kind of leftover from #55 

Some of the dependencies pull in alloc, so I changed it not require `default` for these