### PR TITLE
noise-rust-crypto: disable default features on chacha20poly1305

### DIFF
--- a/noise-rust-crypto/Cargo.toml
+++ b/noise-rust-crypto/Cargo.toml
@@ -20,7 +20,7 @@ use-sha2 = ["sha2"]
 [dependencies]
 x25519-dalek = { version = "2.0.0", optional = true, default-features = false }
 aes-gcm = { version = "0.10.3", features = ["aes"], default-features = false, optional = true }
-chacha20poly1305 = { version = "0.10.1", optional = true }
+chacha20poly1305 = { version = "0.10.1", default-features = false, optional = true }
 blake2 = { version = "0.10.6", optional = true }
 sha2 = { version = "0.10.8", optional = true, default-features = false }
 zeroize = { version = "1", default-features = false }


### PR DESCRIPTION
This dep switched its default features in
https://github.com/RustCrypto/AEADs/commit/d6f510e381c85c0d01069d26ec1d7a87c4cb01ab, enabling `getrandom`, which is not compatible with all targets. This crate does not rely on it.