### PR TITLE
Allow setting local static key lazily in HandshakeState

### DIFF
--- a/noise-protocol/src/handshakestate.rs
+++ b/noise-protocol/src/handshakestate.rs
@@ -423,6 +423,17 @@ where
         self.re.as_ref().map(U8Array::clone)
     }
 
+    /// Set local static key.
+    ///
+    /// Useful if you want to choose the static key based on information
+    /// from previous messages, e.g. remote static pubkey.
+    ///
+    /// Handshake will panic if the static key is not set at a time it
+    /// is expected to be set.
+    pub fn set_s(&mut self, s: D::Key) {
+        self.s = Some(s);
+    }
+
     /// Get whether this [`HandshakeState`] is created as initiator.
     pub fn get_is_initiator(&self) -> bool {
         self.is_initiator


### PR DESCRIPTION
Hello, nice library you've got there! I work for a company that would like to use it in its product with [some changes](https://github.com/trezor/noise-rust/pull/1/commits), most of which don't belong upstream IMHO, except maybe this one?

It allows you to set the static key _after_ HandshakeState is constructed - the idea is to set the key based on previous messages, e.g. based on remote's static key. Not sure whether to also add `assert!(self.s.is_none())` to enforce setting it exactly once.